### PR TITLE
Fix build on nightly

### DIFF
--- a/examples/http-server.rs
+++ b/examples/http-server.rs
@@ -44,7 +44,6 @@ fn main() {
                         let mut buf_i = 0;
                         let mut buf = [0u8; 1024];
 
-                        let mut headers = [httparse::EMPTY_HEADER; 16];
                         loop {
                             let len = try!(conn.read(&mut buf[buf_i..]));
 
@@ -54,6 +53,7 @@ fn main() {
 
                             buf_i += len;
 
+                            let mut headers = [httparse::EMPTY_HEADER; 16];
                             let mut req = httparse::Request::new(&mut headers);
                             let res = req.parse(&buf[0..buf_i]).unwrap();
 

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -23,11 +23,13 @@ struct ChannelShared {
 /// Create with `channel()`
 pub struct Receiver<T>(RcEventSource<ReceiverCore<T>>);
 
-struct ReceiverCore<T> {
+#[doc(hidden)]
+pub struct __ReceiverCore<T> {
     receiver: mpsc::Receiver<T>,
     shared: ArcChannelShared,
     counter: ArcCounter,
 }
+use self::__ReceiverCore as ReceiverCore;
 
 impl<T> EventedImpl for Receiver<T>
     where T: 'static

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -15,11 +15,13 @@ pub struct Timer {
     rc: RcEventSource<TimerCore>,
 }
 
-struct TimerCore {
+#[doc(hidden)]
+pub struct __TimerCore {
     // TODO: Rename these two?
     timeout: Instant,
     mio_timeout: Option<mio_orig::Timeout>,
 }
+use self::__TimerCore as TimerCore;
 
 impl Timer {
     /// Create a new timer


### PR DESCRIPTION
Hi.

https://github.com/rust-lang/rust/pull/46083 turns some compatibility lints in `rustc` into hard errors and regression testing found that this crate is affected. Here's a patch fixing the deprecated code (see https://github.com/rust-lang/rust/issues/34537 and https://github.com/rust-lang/rfcs/pull/2145 for more information about the issue).
